### PR TITLE
add button to see target switch

### DIFF
--- a/SmartOrders/HarmonyPatches/CameraSelectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CameraSelectorPatches.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using HarmonyLib;
+
+namespace SmartOrders.HarmonyPatches;
+
+[HarmonyPatch]
+public static class CameraSelectorPatches
+{
+    [HarmonyReversePatch]
+    [HarmonyPatch(typeof(CameraSelector), "SelectCamera")]
+    public static bool SelectCamera(this CameraSelector __instance, CameraSelector.CameraIdentifier cameraIdentifier) {
+        throw new NotImplementedException("This is a stub");
+    }
+}

--- a/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
@@ -59,7 +59,7 @@ public static class CarInspectorPatches
             BuildRoadModeCouplingButton(builder, locomotive);
         }
 
-        BuildHandbrakeAndAirHelperButons(builder, locomotive);
+        BuildHandbrakeAndAirHelperButtons(builder, locomotive);
     }
 
     private static void BuildRoadModeCouplingButton(UIPanelBuilder builder, BaseLocomotive locomotive)
@@ -82,7 +82,8 @@ public static class CarInspectorPatches
 
     private static void BuildAlternateCarLengthsButtons(UIPanelBuilder builder, BaseLocomotive locomotive, AutoEngineerOrdersHelper helper)
     {
-        builder.AddField("CarLengths", builder.ButtonStrip(delegate (UIPanelBuilder builder)
+        // color is same-ish as vanilla, but it is workaround for bug in UIPanelBuilderPatches ...
+        builder.AddField("Car Lengths".Color("aaaaaa"), builder.ButtonStrip(delegate (UIPanelBuilder builder)
         {
             builder.AddButton("Stop", delegate
             {
@@ -119,7 +120,7 @@ public static class CarInspectorPatches
         }, 4));
     }
 
-    private static void BuildHandbrakeAndAirHelperButons(UIPanelBuilder builder, BaseLocomotive locomotive)
+    private static void BuildHandbrakeAndAirHelperButtons(UIPanelBuilder builder, BaseLocomotive locomotive)
     {
         builder.AddField("",
           builder.ButtonStrip(strip =>
@@ -184,12 +185,6 @@ public static class CarInspectorPatches
                 SmartOrdersUtility.DebugLog("updating switch mode to 'clear under'");
                 locomotive.KeyValueObject.Set("CLEAR_SWITCH_MODE", "CLEAR_UNDER");
             }).Height(60).Tooltip("Clear Under", "Clear switches under the train. Choose the number of switches below");
-
-            builder.AddButtonSelectable("<sprite name=Destination>", getClearSwitchMode(locomotive) == "SHOW_SWITCH", delegate
-            {
-                SmartOrdersUtility.DebugLog("updating switch mode to 'show switch'");
-                locomotive.KeyValueObject.Set("CLEAR_SWITCH_MODE", "SHOW_SWITCH");
-            }).Tooltip("Show me Switch", "Moves camera to target switch");
         })).Height(60);
 
 
@@ -220,7 +215,6 @@ public static class CarInspectorPatches
     {
         bool clearSwitchesUnderTrain = false;
         bool stopBeforeSwitch = false;
-        bool showSwitch = false;
 
         if (mode.IsNull)
         {
@@ -234,23 +228,18 @@ public static class CarInspectorPatches
         else if (mode == "APPROACH_AHEAD")
         {
             stopBeforeSwitch = true;
-        } else if (mode == "SHOW_SWITCH") {
-            showSwitch = true;
         }
-
+        
         SmartOrdersUtility.DebugLog($"Handling move order mode: {mode}, switchesToFind: {switchesToFind}, clearSwitchesUnderTrain: {clearSwitchesUnderTrain}, stopBeforeSwitch: {stopBeforeSwitch}");
 
         var distanceInMeters = SmartOrdersUtility.GetDistanceForSwitchOrder(switchesToFind, clearSwitchesUnderTrain, stopBeforeSwitch, locomotive, persistence, out var targetSwitch);
-        if (showSwitch && targetSwitch != null) {
+        if (SmartOrdersPlugin.Settings.ShowTargetSwitch && targetSwitch != null) {
             SmartOrdersUtility.MoveCameraToNode(targetSwitch);
-            return;
         }
-        if (distanceInMeters != null)
-        {
+
+        if (distanceInMeters != null) {
             MoveDistance(helper, locomotive, distanceInMeters.Value);
-        }
-        else
-        {
+        } else {
             SmartOrdersUtility.DebugLog("ERROR: distanceInMeters is null");
         }
     }

--- a/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
@@ -1,4 +1,6 @@
-﻿namespace SmartOrders.HarmonyPatches;
+﻿using TriangleNet.Voronoi.Legacy;
+
+namespace SmartOrders.HarmonyPatches;
 
 using System;
 using System.Collections.Generic;
@@ -11,6 +13,7 @@ using Model;
 using Model.AI;
 using Model.OpsNew;
 using SmartOrders.Extensions;
+using UI;
 using UI.Builder;
 using UI.CarInspector;
 using UI.Common;
@@ -193,13 +196,14 @@ public static class CarInspectorPatches
             builder.ButtonStrip(
             strip =>
             {
-                strip.AddButton("1", () => MovePastSwitches(helper, 1, locomotive.KeyValueObject.Get("CLEAR_SWITCH_MODE"), locomotive, persistence))!
+                
+                strip.AddButton("1", () => MovePastSwitches(helper, 1, locomotive.KeyValueObject.Get("CLEAR_SWITCH_MODE"), locomotive, persistence, !GameInput.IsShiftDown))!
                     .Tooltip("1 switch", "Move 1 switch");
 
                 for (var i = 2; i <= 10; i++)
                 {
                     var numSwitches = i;
-                    strip.AddButton($"{numSwitches}", () => MovePastSwitches(helper, numSwitches, locomotive.KeyValueObject.Get("CLEAR_SWITCH_MODE"), locomotive, persistence))!
+                    strip.AddButton($"{numSwitches}", () => MovePastSwitches(helper, numSwitches, locomotive.KeyValueObject.Get("CLEAR_SWITCH_MODE"), locomotive, persistence, !GameInput.IsShiftDown))!
                         .Tooltip($"{numSwitches} switches", $"Move {numSwitches} switches");
                 }
             }, 4);
@@ -211,7 +215,7 @@ public static class CarInspectorPatches
         helper.SetOrdersValue(AutoEngineerMode.Yard, null, null, distance);
     }
 
-    private static void MovePastSwitches(AutoEngineerOrdersHelper helper, int switchesToFind, KeyValue.Runtime.Value mode, BaseLocomotive locomotive, AutoEngineerPersistence persistence)
+    private static void MovePastSwitches(AutoEngineerOrdersHelper helper, int switchesToFind, KeyValue.Runtime.Value mode, BaseLocomotive locomotive, AutoEngineerPersistence persistence, bool showTargetSwitch)
     {
         bool clearSwitchesUnderTrain = false;
         bool stopBeforeSwitch = false;
@@ -233,7 +237,7 @@ public static class CarInspectorPatches
         SmartOrdersUtility.DebugLog($"Handling move order mode: {mode}, switchesToFind: {switchesToFind}, clearSwitchesUnderTrain: {clearSwitchesUnderTrain}, stopBeforeSwitch: {stopBeforeSwitch}");
 
         var distanceInMeters = SmartOrdersUtility.GetDistanceForSwitchOrder(switchesToFind, clearSwitchesUnderTrain, stopBeforeSwitch, locomotive, persistence, out var targetSwitch);
-        if (SmartOrdersPlugin.Settings.ShowTargetSwitch && targetSwitch != null) {
+        if (SmartOrdersPlugin.Settings.ShowTargetSwitch && showTargetSwitch && targetSwitch != null) {
             SmartOrdersUtility.MoveCameraToNode(targetSwitch);
         }
 

--- a/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
@@ -237,8 +237,8 @@ public static class CarInspectorPatches
         SmartOrdersUtility.DebugLog($"Handling move order mode: {mode}, switchesToFind: {switchesToFind}, clearSwitchesUnderTrain: {clearSwitchesUnderTrain}, stopBeforeSwitch: {stopBeforeSwitch}");
 
         var distanceInMeters = SmartOrdersUtility.GetDistanceForSwitchOrder(switchesToFind, clearSwitchesUnderTrain, stopBeforeSwitch, locomotive, persistence, out var targetSwitch);
-        if (SmartOrdersPlugin.Settings.ShowTargetSwitch && showTargetSwitch && targetSwitch != null) {
-            SmartOrdersUtility.MoveCameraToNode(targetSwitch);
+        if (SmartOrdersPlugin.Settings.ShowTargetSwitch && showTargetSwitch && targetSwitch != null && distanceInMeters != null) {
+            SmartOrdersUtility.MoveCameraToNode(targetSwitch, distanceInMeters.Value);
         }
 
         if (distanceInMeters != null) {

--- a/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
@@ -184,6 +184,12 @@ public static class CarInspectorPatches
                 SmartOrdersUtility.DebugLog("updating switch mode to 'clear under'");
                 locomotive.KeyValueObject.Set("CLEAR_SWITCH_MODE", "CLEAR_UNDER");
             }).Height(60).Tooltip("Clear Under", "Clear switches under the train. Choose the number of switches below");
+
+            builder.AddButtonSelectable("<sprite name=Destination>", getClearSwitchMode(locomotive) == "SHOW_SWITCH", delegate
+            {
+                SmartOrdersUtility.DebugLog("updating switch mode to 'show switch'");
+                locomotive.KeyValueObject.Set("CLEAR_SWITCH_MODE", "SHOW_SWITCH");
+            }).Tooltip("Show me Switch", "Moves camera to target switch");
         })).Height(60);
 
 
@@ -214,6 +220,7 @@ public static class CarInspectorPatches
     {
         bool clearSwitchesUnderTrain = false;
         bool stopBeforeSwitch = false;
+        bool showSwitch = false;
 
         if (mode.IsNull)
         {
@@ -227,11 +234,17 @@ public static class CarInspectorPatches
         else if (mode == "APPROACH_AHEAD")
         {
             stopBeforeSwitch = true;
+        } else if (mode == "SHOW_SWITCH") {
+            showSwitch = true;
         }
 
         SmartOrdersUtility.DebugLog($"Handling move order mode: {mode}, switchesToFind: {switchesToFind}, clearSwitchesUnderTrain: {clearSwitchesUnderTrain}, stopBeforeSwitch: {stopBeforeSwitch}");
 
-        var distanceInMeters = SmartOrdersUtility.GetDistanceForSwitchOrder(switchesToFind, clearSwitchesUnderTrain, stopBeforeSwitch, locomotive, persistence);
+        var distanceInMeters = SmartOrdersUtility.GetDistanceForSwitchOrder(switchesToFind, clearSwitchesUnderTrain, stopBeforeSwitch, locomotive, persistence, out var targetSwitch);
+        if (showSwitch && targetSwitch != null) {
+            SmartOrdersUtility.MoveCameraToNode(targetSwitch);
+            return;
+        }
         if (distanceInMeters != null)
         {
             MoveDistance(helper, locomotive, distanceInMeters.Value);

--- a/SmartOrders/Helpers/TrackNodeHelper.cs
+++ b/SmartOrders/Helpers/TrackNodeHelper.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using Track;
 using UnityEngine;
@@ -39,5 +40,8 @@ public sealed class TrackNodeHelper : MonoBehaviour
     private IEnumerator Routine() {
         yield return new WaitForSecondsRealtime(2f);
         _LineRenderer!.enabled = false;
+        OnHidden?.Invoke();
     }
+
+    public Action? OnHidden;
 }

--- a/SmartOrders/Helpers/TrackNodeHelper.cs
+++ b/SmartOrders/Helpers/TrackNodeHelper.cs
@@ -7,41 +7,104 @@ namespace SmartOrders.Helpers;
 
 public sealed class TrackNodeHelper : MonoBehaviour
 {
+    private const float CenterZ = 2;
+    private const float HalfHeight = 0.5f;
+    private const float HalfWidth = 0.2f;
+    //private const float ArrowSize = 2f;
+    //private const float ArrowHeight = 0.5f;
+    //private const float ArrowWidth = 0.2f;
+
     private static readonly Material _LineMaterial = new(Shader.Find("Universal Render Pipeline/Lit")!);
+    //private LineRenderer? _LineRenderer;
+    //private LineRenderer CreateLineRenderer() {
+    //    var lineRenderer = gameObject!.AddComponent<LineRenderer>()!;
+    //    lineRenderer.material = _LineMaterial;
+    //    lineRenderer.material.color = Color.yellow;
+    //    lineRenderer.startWidth = 0.05f;
+    //    lineRenderer.positionCount = 5;
+    //    lineRenderer.useWorldSpace = false;
+    //    lineRenderer.SetPosition(0, new Vector3(-ArrowWidth, ArrowHeight, 0));
+    //    lineRenderer.SetPosition(1, new Vector3(0, 0, 0));
+    //    lineRenderer.SetPosition(2, new Vector3(0, ArrowSize, 0));
+    //    lineRenderer.SetPosition(3, new Vector3(0, 0, 0));
+    //    lineRenderer.SetPosition(4, new Vector3(ArrowWidth, ArrowHeight, 0));
+    //    lineRenderer.enabled = true;
+    //    return lineRenderer;
+    //}
 
-    private LineRenderer? _LineRenderer;
+    private MeshFilter? _MeshFilter;
+    private MeshRenderer? _MeshRenderer;
 
-    private LineRenderer CreateLineRenderer() {
-        var lineRenderer = gameObject!.AddComponent<LineRenderer>()!;
-        lineRenderer.material = _LineMaterial;
-        lineRenderer.material.color = Color.yellow;
-        lineRenderer.startWidth = 0.05f;
-        lineRenderer.positionCount = 5;
-        lineRenderer.useWorldSpace = false;
-        lineRenderer.SetPosition(0, new Vector3(-0.2f, 0.5f, 0));
-        lineRenderer.SetPosition(1, new Vector3(0, 0, 0));
-        lineRenderer.SetPosition(2, new Vector3(0, 4, 0));
-        lineRenderer.SetPosition(3, new Vector3(0, 0, 0));
-        lineRenderer.SetPosition(4, new Vector3(0.2f, 0.5f, 0));
-        lineRenderer.enabled = true;
-        return lineRenderer;
+    private Mesh CreateMesh(float k) {
+        // Create a new Mesh
+        Mesh mesh = new Mesh();
+
+        var k2 = k / 2;
+
+        // Define vertices of an octahedron
+        Vector3[] vertices = new Vector3[] {
+            new Vector3(0, k2 * (CenterZ + HalfHeight), 0), // Top vertex
+            new Vector3(0, k2 * (CenterZ - HalfHeight), 0), // Bottom vertex
+            new Vector3(k * HalfWidth, k2 * CenterZ, 0),    // Front vertex
+            new Vector3(k * -HalfWidth, k2 * CenterZ, 0),   // Back vertex
+            new Vector3(0, k2 * CenterZ, k * HalfWidth),     // Right vertex
+            new Vector3(0, k2 * CenterZ, k * -HalfWidth)     // Left vertex
+        };
+
+        // Define the triangles of the octahedron
+        int[] triangles = new int[]
+        {
+            // Top pyramid
+            0, 4, 2,
+            0, 3, 4,
+            0, 5, 3,
+            0, 2, 5,
+
+            // Bottom pyramid
+            1, 2, 4,
+            1, 4, 3,
+            1, 3, 5,
+            1, 5, 2,
+        };
+
+        mesh.vertices = vertices;
+        mesh.triangles = triangles;
+
+        mesh.RecalculateNormals();
+        mesh.uv = new Vector2[vertices.Length];
+
+        return mesh;
     }
-
-    public void Show(TrackNode node) {
+    
+    public void Show(TrackNode node, float distanceInMeters) {
         gameObject!.transform!.SetParent(node.transform!);
         gameObject.transform.localPosition = Vector3.zero;
         gameObject.transform.localRotation = Quaternion.identity;
+        gameObject.transform.localScale = new Vector3(2, 5, 2);
 
-        _LineRenderer ??= CreateLineRenderer();
-        _LineRenderer.enabled = true;
+        //_LineRenderer ??= CreateLineRenderer();
+        //_LineRenderer.enabled = true;
+
+        var k = distanceInMeters < 100 ? 1 : (distanceInMeters - 100f) / 50f;
+        
+        _MeshFilter ??= gameObject!.AddComponent<MeshFilter>()!;
+        _MeshFilter.mesh = CreateMesh(k);
+
+        if (_MeshRenderer == null) {
+            _MeshRenderer = gameObject.AddComponent<MeshRenderer>()!;
+            _MeshRenderer.material =  _LineMaterial;
+            _MeshRenderer.material.color = Color.magenta;
+        }
+
+        _MeshRenderer.enabled = true;
+
         StartCoroutine(Routine());
     }
 
     private IEnumerator Routine() {
         yield return new WaitForSecondsRealtime(2f);
-        _LineRenderer!.enabled = false;
-        OnHidden?.Invoke();
+        _MeshRenderer!.enabled = false;
+        //_LineRenderer!.enabled = false;
     }
 
-    public Action? OnHidden;
 }

--- a/SmartOrders/Helpers/TrackNodeHelper.cs
+++ b/SmartOrders/Helpers/TrackNodeHelper.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using Track;
+using UnityEngine;
+
+namespace SmartOrders.Helpers;
+
+public sealed class TrackNodeHelper : MonoBehaviour
+{
+    private static readonly Material _LineMaterial = new(Shader.Find("Universal Render Pipeline/Lit")!);
+
+    private LineRenderer? _LineRenderer;
+
+    private LineRenderer CreateLineRenderer() {
+        var lineRenderer = gameObject!.AddComponent<LineRenderer>()!;
+        lineRenderer.material = _LineMaterial;
+        lineRenderer.material.color = Color.yellow;
+        lineRenderer.startWidth = 0.05f;
+        lineRenderer.positionCount = 5;
+        lineRenderer.useWorldSpace = false;
+        lineRenderer.SetPosition(0, new Vector3(-0.2f, 0.5f, 0));
+        lineRenderer.SetPosition(1, new Vector3(0, 0, 0));
+        lineRenderer.SetPosition(2, new Vector3(0, 4, 0));
+        lineRenderer.SetPosition(3, new Vector3(0, 0, 0));
+        lineRenderer.SetPosition(4, new Vector3(0.2f, 0.5f, 0));
+        lineRenderer.enabled = true;
+        return lineRenderer;
+    }
+
+    public void Show(TrackNode node) {
+        gameObject!.transform!.SetParent(node.transform!);
+        gameObject.transform.localPosition = Vector3.zero;
+        gameObject.transform.localRotation = Quaternion.identity;
+
+        _LineRenderer ??= CreateLineRenderer();
+        _LineRenderer.enabled = true;
+        StartCoroutine(Routine());
+    }
+
+    private IEnumerator Routine() {
+        yield return new WaitForSecondsRealtime(2f);
+        _LineRenderer!.enabled = false;
+    }
+}

--- a/SmartOrders/Settings.cs
+++ b/SmartOrders/Settings.cs
@@ -9,6 +9,7 @@ public class Settings
     public bool AutoApplyHandbrake { get; set; }
 
     public bool NoYardSpeedLimit {  get; set; }
+    public bool ShowTargetSwitch {  get; set; }
 
     public MeasureType MeasureType { get; set; }
 

--- a/SmartOrders/SmartOrdersPlugin.cs
+++ b/SmartOrders/SmartOrdersPlugin.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using GalaSoft.MvvmLight.Messaging;
+using Game.Events;
 using SmartOrders.Helpers;
 using UnityEngine;
 
@@ -6,7 +8,6 @@ namespace SmartOrders;
 
 using System;
 using System.Linq;
-using Game.Events;
 using HarmonyLib;
 using JetBrains.Annotations;
 using Railloader;
@@ -23,7 +24,7 @@ public sealed class SmartOrdersPlugin : SingletonPluginBase<SmartOrdersPlugin>, 
 
     public static TrackNodeHelper TrackNodeHelper { get; private set; }
 
-    private readonly ILogger _Logger = Log.ForContext<SmartOrdersPlugin>()!;
+    private readonly Serilog.ILogger _Logger = Serilog.Log.ForContext<SmartOrdersPlugin>()!;
 
     public SmartOrdersPlugin(IModdingContext context, IUIHelper uiHelper)
     {
@@ -63,25 +64,30 @@ public sealed class SmartOrdersPlugin : SingletonPluginBase<SmartOrdersPlugin>, 
     }
 
     public void ModTabDidOpen(UIPanelBuilder builder) {
-        var lengths = Enum.GetNames(typeof(MeasureType)).ToList();
+        // 'Display names' from values from MeasureType enum
+        List<string> lengths = ["Feet", "Meter", "Car Lengths"];
         builder.AddField("Measure distance in", builder.AddDropdown(lengths, (int)Settings.MeasureType, o => {
             Settings.MeasureType = (MeasureType)o;
             builder.Rebuild();
         })!);
 
-        builder.AddField("Apply handbrakes", builder.AddToggle(() => Settings.AutoApplyHandbrake, o => Settings.AutoApplyHandbrake = o)!)
+        builder.AddField("Apply handbrakes", builder.AddToggle(() => Settings.AutoApplyHandbrake, o => Settings.AutoApplyHandbrake = o)!)!
                 .Tooltip("Apply handbrakes", "When decoupling stationary cars, set the handbrake in the first car");
 
-        builder.AddField("Release handbrakes", builder.AddToggle(() => Settings.AutoReleaseHandbrake, o => Settings.AutoReleaseHandbrake = o)!)
+        builder.AddField("Release handbrakes", builder.AddToggle(() => Settings.AutoReleaseHandbrake, o => Settings.AutoReleaseHandbrake = o)!)!
                 .Tooltip("Release handbrakes", "In Yard mode, automatically release the handbrakes for any cars in the train before moving");
 
-        builder.AddField("Couple air", builder.AddToggle(() => Settings.AutoCoupleAir, o => Settings.AutoCoupleAir = o)!)
+        builder.AddField("Couple air", builder.AddToggle(() => Settings.AutoCoupleAir, o => Settings.AutoCoupleAir = o)!)!
                 .Tooltip("Couple air", "In Yard mode, automatically couple air and open anglecocks for any cars in the train before moving");
 
-        builder.AddField("Remove Yard Mode Speed Limit", builder.AddToggle(() => Settings.NoYardSpeedLimit, o => Settings.NoYardSpeedLimit = o)!)
+        builder.AddField("No Yard Speed Limit", builder.AddToggle(() => Settings.NoYardSpeedLimit, o => Settings.NoYardSpeedLimit = o)!)!
                 .Tooltip("Remove Yard Mode Speed Limit", "Remove 15mph speed limit in yard mode");
 
-        builder.AddField("Send debug logs to console", builder.AddToggle(() => Settings.EnableDebug, o => Settings.EnableDebug = o)!);
+        builder.AddField("Show Target Switch", builder.AddToggle(() => Settings.ShowTargetSwitch, o => Settings.ShowTargetSwitch = o)!)!
+               .Tooltip("Show Target Switch", "Moves camera to target switch and show yellow arrow pointing on switch node.");
+
+        builder.AddField("Debug logs", builder.AddToggle(() => Settings.EnableDebug, o => Settings.EnableDebug = o)!)!
+               .Tooltip("Send debug logs to console", "Send debug logs to console.");
     }
 
     public void ModTabDidClose()

--- a/SmartOrders/SmartOrdersPlugin.cs
+++ b/SmartOrders/SmartOrdersPlugin.cs
@@ -1,3 +1,6 @@
+using SmartOrders.Helpers;
+using UnityEngine;
+
 namespace SmartOrders;
 
 using System;
@@ -16,6 +19,8 @@ public sealed class SmartOrdersPlugin : SingletonPluginBase<SmartOrdersPlugin>, 
     public static IUIHelper UiHelper { get; private set; } = null!;
     public static Settings Settings { get; private set; }
 
+    public static TrackNodeHelper TrackNodeHelper { get; private set; }
+
     private readonly ILogger _Logger = Log.ForContext<SmartOrdersPlugin>()!;
 
     public SmartOrdersPlugin(IModdingContext context, IUIHelper uiHelper)
@@ -31,6 +36,9 @@ public sealed class SmartOrdersPlugin : SingletonPluginBase<SmartOrdersPlugin>, 
         _Logger.Information("OnEnable");
         var harmony = new Harmony("SmartOrders");
         harmony.PatchAll();
+
+        var go = new GameObject();
+        TrackNodeHelper = go.AddComponent<TrackNodeHelper>()!;
     }
 
     public override void OnDisable()
@@ -38,6 +46,9 @@ public sealed class SmartOrdersPlugin : SingletonPluginBase<SmartOrdersPlugin>, 
         _Logger.Information("OnDisable");
         var harmony = new Harmony("SmartOrders");
         harmony.UnpatchAll();
+
+        UnityEngine.Object.Destroy(TrackNodeHelper.gameObject!);
+        TrackNodeHelper = null!;
     }
 
     public void ModTabDidOpen(UIPanelBuilder builder) {

--- a/SmartOrders/SmartOrdersPlugin.cs
+++ b/SmartOrders/SmartOrdersPlugin.cs
@@ -1,3 +1,4 @@
+using GalaSoft.MvvmLight.Messaging;
 using SmartOrders.Helpers;
 using UnityEngine;
 
@@ -5,6 +6,7 @@ namespace SmartOrders;
 
 using System;
 using System.Linq;
+using Game.Events;
 using HarmonyLib;
 using JetBrains.Annotations;
 using Railloader;
@@ -37,8 +39,8 @@ public sealed class SmartOrdersPlugin : SingletonPluginBase<SmartOrdersPlugin>, 
         var harmony = new Harmony("SmartOrders");
         harmony.PatchAll();
 
-        var go = new GameObject();
-        TrackNodeHelper = go.AddComponent<TrackNodeHelper>()!;
+        Messenger.Default!.Register(this, new Action<MapDidLoadEvent>(OnMapDidLoad));
+        Messenger.Default.Register(this, new Action<MapDidUnloadEvent>(OnMapDidUnload));
     }
 
     public override void OnDisable()
@@ -47,6 +49,15 @@ public sealed class SmartOrdersPlugin : SingletonPluginBase<SmartOrdersPlugin>, 
         var harmony = new Harmony("SmartOrders");
         harmony.UnpatchAll();
 
+        Messenger.Default!.Unregister(this);
+    }
+
+    private void OnMapDidLoad(MapDidLoadEvent obj) {
+        var go = new GameObject();
+        TrackNodeHelper = go.AddComponent<TrackNodeHelper>()!;
+    }
+
+    private void OnMapDidUnload(MapDidUnloadEvent obj) {
         UnityEngine.Object.Destroy(TrackNodeHelper.gameObject!);
         TrackNodeHelper = null!;
     }

--- a/SmartOrders/SmartOrdersUtility.cs
+++ b/SmartOrders/SmartOrdersUtility.cs
@@ -454,28 +454,29 @@ public static class SmartOrdersUtility
         carToDisconnect.ApplyEndGearChange(carToDisconnectEndToDisconnect, EndGearStateKey.Anglecock, 0f);
     }
     
-    public static void MoveCameraToNode(TrackNode node) {
-        var isFirstPerson = CameraSelector.shared!.CurrentCameraIsFirstPerson;
-        var initial = CameraSelector.shared.CurrentCameraPosition;
+    public static void MoveCameraToNode(TrackNode node, float distanceInMeters) {
+        // move camera to switch
+        //var isFirstPerson = CameraSelector.shared!.CurrentCameraIsFirstPerson;
+        //var initial = CameraSelector.shared.CurrentCameraPosition;
 
-        // move camera
-        CameraSelector.shared.ZoomToPoint(node.transform!.localPosition);
+        //// move camera
+        //CameraSelector.shared.ZoomToPoint(node.transform!.localPosition);
 
-        var afterMove = CameraSelector.shared.CurrentCameraPosition;
-        SmartOrdersPlugin.TrackNodeHelper.OnHidden = () => {
-            // move camera back if was not moved when arrows hides itself 
-            var current = CameraSelector.shared!.CurrentCameraPosition;
-            if (current == afterMove) {
-                if (isFirstPerson) {
-                    CameraSelector.shared.SelectCamera(CameraSelector.CameraIdentifier.FirstPerson);
-                } else {
-                    CameraSelector.shared.ZoomToPoint(initial);
-                }
-            }
-        };
+        //var afterMove = CameraSelector.shared.CurrentCameraPosition;
+        //SmartOrdersPlugin.TrackNodeHelper.OnHidden = () => {
+        //    // move camera back if was not moved when arrows hides itself 
+        //    var current = CameraSelector.shared!.CurrentCameraPosition;
+        //    if (current == afterMove) {
+        //        if (isFirstPerson) {
+        //            CameraSelector.shared.SelectCamera(CameraSelector.CameraIdentifier.FirstPerson);
+        //        } else {
+        //            CameraSelector.shared.ZoomToPoint(initial);
+        //        }
+        //    }
+        //};
 
         // show arrow for 2 seconds
-        SmartOrdersPlugin.TrackNodeHelper.Show(node);
+        SmartOrdersPlugin.TrackNodeHelper.Show(node, distanceInMeters);
     }
 
 }

--- a/SmartOrders/SmartOrdersUtility.cs
+++ b/SmartOrders/SmartOrdersUtility.cs
@@ -50,8 +50,8 @@ public static class SmartOrdersUtility
         locomotive.EnumerateCoupled().Do(c => c.SetHandbrake(false));
     }
 
-    public static float? GetDistanceForSwitchOrder(int switchesToFind, bool clearSwitchesUnderTrain, bool stopBeforeSwitch, BaseLocomotive locomotive, AutoEngineerPersistence persistence)
-    {
+    public static float? GetDistanceForSwitchOrder(int switchesToFind, bool clearSwitchesUnderTrain, bool stopBeforeSwitch, BaseLocomotive locomotive, AutoEngineerPersistence persistence, out TrackNode? targetSwitch) {
+        targetSwitch = null;
         if (!SmartOrdersPlugin.Shared.IsEnabled)
         {
             return null;
@@ -155,6 +155,8 @@ public static class SmartOrdersUtility
                 break;
             }
 
+            targetSwitch = node;
+
             if (graph.IsSwitch(node))
             {
                 DebugLog($"Found next switch at {distanceInMeters}m");
@@ -215,6 +217,7 @@ public static class SmartOrdersUtility
         if (foundAllSwitches)
         {
             var node = segment.NodeForEnd(segmentEnd);
+            targetSwitch = node;
 
             graph.DecodeSwitchAt(node, out var switchEnterSegment, out _, out _);
             var nodeFoulingDistance = graph.CalculateFoulingDistance(node);
@@ -256,6 +259,9 @@ public static class SmartOrdersUtility
 
         distanceInMeters = Math.Max(0, distanceInMeters);
 
+        // NOTE: This should not be here ... (method should only return distance  + targetSwitch
+        //    and not also print message to console)
+        // >>
         var action = "Reversing";
         if (orders.Forward)
         {
@@ -297,7 +303,7 @@ public static class SmartOrdersUtility
         {
             Say($"{action} {distanceString}");
         }
-
+        // <<
         return distanceInMeters;
     }
 
@@ -446,6 +452,11 @@ public static class SmartOrdersUtility
         newEndCar.ApplyEndGearChange(newEndCarEndToDisconnect, EndGearStateKey.CutLever, 1f);
         newEndCar.ApplyEndGearChange(newEndCarEndToDisconnect, EndGearStateKey.Anglecock, 0f);
         carToDisconnect.ApplyEndGearChange(carToDisconnectEndToDisconnect, EndGearStateKey.Anglecock, 0f);
+    }
+    
+    public static void MoveCameraToNode(TrackNode node){
+         CameraSelector.shared.ZoomToPoint(node.transform.localPosition);
+         SmartOrdersPlugin.TrackNodeHelper.Show(node);
     }
 
 }

--- a/SmartOrders/SmartOrdersUtility.cs
+++ b/SmartOrders/SmartOrdersUtility.cs
@@ -454,9 +454,13 @@ public static class SmartOrdersUtility
         carToDisconnect.ApplyEndGearChange(carToDisconnectEndToDisconnect, EndGearStateKey.Anglecock, 0f);
     }
     
-    public static void MoveCameraToNode(TrackNode node){
-         CameraSelector.shared.ZoomToPoint(node.transform.localPosition);
-         SmartOrdersPlugin.TrackNodeHelper.Show(node);
+    public static void MoveCameraToNode(TrackNode node) {
+        var position = CameraSelector.shared!.CurrentCameraPosition;
+        SmartOrdersPlugin.TrackNodeHelper.OnHidden = () => CameraSelector.shared.ZoomToPoint(position);
+
+        CameraSelector.shared.ZoomToPoint(node.transform!.localPosition);
+
+        SmartOrdersPlugin.TrackNodeHelper.Show(node);
     }
 
 }

--- a/SmartOrders/SmartOrdersUtility.cs
+++ b/SmartOrders/SmartOrdersUtility.cs
@@ -455,11 +455,26 @@ public static class SmartOrdersUtility
     }
     
     public static void MoveCameraToNode(TrackNode node) {
-        var position = CameraSelector.shared!.CurrentCameraPosition;
-        SmartOrdersPlugin.TrackNodeHelper.OnHidden = () => CameraSelector.shared.ZoomToPoint(position);
+        var isFirstPerson = CameraSelector.shared!.CurrentCameraIsFirstPerson;
+        var initial = CameraSelector.shared.CurrentCameraPosition;
 
+        // move camera
         CameraSelector.shared.ZoomToPoint(node.transform!.localPosition);
 
+        var afterMove = CameraSelector.shared.CurrentCameraPosition;
+        SmartOrdersPlugin.TrackNodeHelper.OnHidden = () => {
+            // move camera back if was not moved when arrows hides itself 
+            var current = CameraSelector.shared!.CurrentCameraPosition;
+            if (current == afterMove) {
+                if (isFirstPerson) {
+                    CameraSelector.shared.SelectCamera(CameraSelector.CameraIdentifier.FirstPerson);
+                } else {
+                    CameraSelector.shared.ZoomToPoint(initial);
+                }
+            }
+        };
+
+        // show arrow for 2 seconds
         SmartOrdersPlugin.TrackNodeHelper.Show(node);
     }
 


### PR DESCRIPTION
i didnt want to count the switches, so i added new button to UI, that will nove camera to target switch and renders yellow arrow on it (for 2 seconds)

![image](https://github.com/user-attachments/assets/c2d5f1f1-d42e-4f52-b61e-bed5cdbacfdc)

in this case i clicked on button '1' ....

Tooltip may need some tweaks ...
