### PR TITLE
Added extra check when removing vanilla "Car Lengths" field

### DIFF
--- a/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
@@ -23,10 +23,18 @@ using static Model.Car;
 [HarmonyPatch]
 public static class CarInspectorPatches
 {
+    public static bool InsidePopulateAIPanel;
+
 
     const float ADDITIONAL_WINDOW_HEIGHT_NEEDED = 95;
     private static Vector2? originalWindowSize;
 
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(CarInspector), "PopulateAIPanel")]
+    public static void PopulateAIPanelPrefix() {
+        InsidePopulateAIPanel = true;
+    }
+    
     [HarmonyPrefix]
     [HarmonyPatch(typeof(CarInspector), "BuildContextualOrders")]
     public static void BuildContextualOrders(UIPanelBuilder builder, AutoEngineerPersistence persistence, Car ____car, Window ____window)
@@ -35,6 +43,9 @@ public static class CarInspectorPatches
         {
             return;
         }
+
+        InsidePopulateAIPanel = false;
+
         var locomotive = (BaseLocomotive)____car;
         var helper = new AutoEngineerOrdersHelper(locomotive, persistence);
         var mode2 = helper.Mode();
@@ -82,7 +93,7 @@ public static class CarInspectorPatches
 
     private static void BuildAlternateCarLengthsButtons(UIPanelBuilder builder, BaseLocomotive locomotive, AutoEngineerOrdersHelper helper)
     {
-        builder.AddField("CarLengths", builder.ButtonStrip(delegate (UIPanelBuilder builder)
+        builder.AddField("Car Lengths", builder.ButtonStrip(delegate (UIPanelBuilder builder)
         {
             builder.AddButton("Stop", delegate
             {

--- a/SmartOrders/HarmonyPatches/UIPanelBuilderPatches.cs
+++ b/SmartOrders/HarmonyPatches/UIPanelBuilderPatches.cs
@@ -18,7 +18,7 @@ public static class UIPanelBuilderPatches
     [HarmonyPatch(new Type[] { typeof(string), typeof(RectTransform) })]
     public static bool AddField(string label, RectTransform control)
     {
-        if (!SmartOrdersPlugin.Shared.IsEnabled)
+        if (!SmartOrdersPlugin.Shared.IsEnabled || !CarInspectorPatches.InsidePopulateAIPanel)
         {
             return true;
         }
@@ -34,7 +34,7 @@ public static class UIPanelBuilderPatches
     [HarmonyPatch(typeof(UIPanelBuilder), "ButtonStrip")]
     public static bool ButtonStrip(Action<UIPanelBuilder> closure, int spacing = 8)
     {
-        if (!SmartOrdersPlugin.Shared.IsEnabled)
+        if (!SmartOrdersPlugin.Shared.IsEnabled || !CarInspectorPatches.InsidePopulateAIPanel)
         {
             return true;
         }
@@ -53,7 +53,7 @@ public static class UIPanelBuilderPatches
     [HarmonyPatch(typeof(UIPanelBuilder), "AddExpandingVerticalSpacer")]
     public static bool AddExpandingVerticalSpacer()
     {
-        if (!SmartOrdersPlugin.Shared.IsEnabled)
+        if (!SmartOrdersPlugin.Shared.IsEnabled || !CarInspectorPatches.InsidePopulateAIPanel)
         {
             return true;
         }


### PR DESCRIPTION
this bug was messing up my own dialog in unrelated mod - was unable to use `builder.AddField("Car Lengths", ...);`

code now checking if is building UI inside PopulateAIPanel method before removing stuff ...

edit: still believe thaet even better solution would be to use harmony to modify IL code of PopulateAIPanel  method to correctly remove ONLY fields declared in that method ... (sure, code will break if game updates that method, but i think that is still better than now ....)
