### PR TITLE
Bandaid fix to load on RR 2024.6 using RL 1.9.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ SmartOrders/obj
 _ReSharper.Caches
 *.user
 *.zip
+/Paths.user.sample
+/.gitignore

--- a/Paths.user.sample
+++ b/Paths.user.sample
@@ -1,6 +1,0 @@
-﻿<Project>
-  <PropertyGroup>
-    <!-- Directory that the game (Railroader.exe) is in -->
-    <GameDir>C:\Steam\steamapps\common\Railroader</GameDir>
-  </PropertyGroup>
-</Project>

--- a/SmartOrders/Definition.json
+++ b/SmartOrders/Definition.json
@@ -2,7 +2,7 @@
     "manifestVersion": 1,
     "id": "SmartOrders",
     "name": "SmartOrders",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "assemblies": [
         "SmartOrders"
     ]

--- a/SmartOrders/HarmonyPatches/AutoEngineerOrdersExtensionsPatches.cs
+++ b/SmartOrders/HarmonyPatches/AutoEngineerOrdersExtensionsPatches.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Game.Messages;
 using HarmonyLib;
+using Model.AI;
 using Track;
 using UI.EngineControls;
 

--- a/SmartOrders/HarmonyPatches/AutoEngineerOrdersExtensionsPatches.cs
+++ b/SmartOrders/HarmonyPatches/AutoEngineerOrdersExtensionsPatches.cs
@@ -4,6 +4,7 @@ using System;
 using System.Diagnostics.CodeAnalysis;
 using Game.Messages;
 using HarmonyLib;
+using Model.AI;
 using Track;
 using UI.EngineControls;
 
@@ -20,6 +21,7 @@ public static class AutoEngineerOrdersExtensionsPatches
             AutoEngineerMode.Off => 0,
             AutoEngineerMode.Road => 45,
             AutoEngineerMode.Yard => SmartOrdersPlugin.Settings.NoYardSpeedLimit ? 45 : 15,
+            AutoEngineerMode.Waypoint => 45,
             _ => throw new ArgumentOutOfRangeException("mode", mode, null),
         };
     }

--- a/SmartOrders/HarmonyPatches/AutoEngineerPlannerPatches.cs
+++ b/SmartOrders/HarmonyPatches/AutoEngineerPlannerPatches.cs
@@ -15,22 +15,22 @@ using UnityEngine;
 public static class AutoEngineerPlannerPatches
 {
 
-    [HarmonyPrefix]
-    [HarmonyPatch(typeof(AutoEngineerPlanner), "Search")]
-    private static void Search(BaseLocomotive locomotive, ref bool stopBeforeCar)
-    {
-        if (!SmartOrdersPlugin.Shared.IsEnabled)
-        {
-            return;
-        }
+    //[HarmonyPrefix]
+    //[HarmonyPatch(typeof(AutoEngineerPlanner), "Search")]
+    //private static void Search(BaseLocomotive locomotive, ref bool stopBeforeCar)
+    //{
+    //    if (!SmartOrdersPlugin.Shared.IsEnabled)
+    //    {
+    //        return;
+    //    }
 
 
-        bool allowCouplingInRoadMode = locomotive.KeyValueObject.Get("ALLOW_COUPLING_IN_ROAD_MODE").BoolValue;
+    //    bool allowCouplingInRoadMode = locomotive.KeyValueObject.Get("ALLOW_COUPLING_IN_ROAD_MODE").BoolValue;
 
-        if (allowCouplingInRoadMode && stopBeforeCar)
-        {
-            stopBeforeCar = false;
-        }
-    }
+    //    if (allowCouplingInRoadMode && stopBeforeCar)
+    //    {
+    //        stopBeforeCar = false;
+    //    }
+    //}
 
 }

--- a/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
@@ -37,7 +37,7 @@ public static class CarInspectorPatches
         }
         var locomotive = (BaseLocomotive)____car;
         var helper = new AutoEngineerOrdersHelper(locomotive, persistence);
-        var mode2 = helper.Mode();
+        var mode2 = helper.Mode;
 
         if (mode2 == AutoEngineerMode.Yard)
         {
@@ -54,10 +54,10 @@ public static class CarInspectorPatches
 
         //BuildDisconnectCarsButtons(builder, locomotive, persistence, helper);
 
-        if (mode2 == AutoEngineerMode.Road)
-        {
-            BuildRoadModeCouplingButton(builder, locomotive);
-        }
+        //if (mode2 == AutoEngineerMode.Road)
+        //{
+        //    BuildRoadModeCouplingButton(builder, locomotive);
+        //}
 
         BuildHandbrakeAndAirHelperButons(builder, locomotive);
     }
@@ -245,7 +245,7 @@ public static class CarInspectorPatches
     // Not currently used but could be added if we want to merge FlyShuntUI into SmartOrders
     static void BuildDisconnectCarsButtons(UIPanelBuilder builder, BaseLocomotive locomotive, AutoEngineerPersistence persistence, AutoEngineerOrdersHelper helper)
     {
-        AutoEngineerMode mode2 = helper.Mode();
+        AutoEngineerMode mode2 = helper.Mode;
 
         builder.AddField("Disconnect", builder.ButtonStrip(delegate (UIPanelBuilder bldr)
         {

--- a/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
+++ b/SmartOrders/HarmonyPatches/CarInspectorPatches.cs
@@ -9,7 +9,7 @@ using HarmonyLib;
 using JetBrains.Annotations;
 using Model;
 using Model.AI;
-using Model.OpsNew;
+using Model.Ops;
 using SmartOrders.Extensions;
 using UI.Builder;
 using UI.CarInspector;

--- a/SmartOrders/SmartOrdersUtility.cs
+++ b/SmartOrders/SmartOrdersUtility.cs
@@ -16,7 +16,7 @@ using UI.Common;
 using UnityEngine;
 using Game;
 using Network.Messages;
-using Model.OpsNew;
+using Model.Ops;
 using static Model.Car;
 
 public static class SmartOrdersUtility

--- a/SmartOrders/SmartOrdersUtility.cs
+++ b/SmartOrders/SmartOrdersUtility.cs
@@ -314,7 +314,7 @@ public static class SmartOrdersUtility
 
     private static void Say(string message)
     {
-        Alert alert = new Alert(AlertStyle.Console, message, TimeWeather.Now.TotalSeconds);
+        Alert alert = new Alert(AlertStyle.Console, AlertLevel.Info, message, TimeWeather.Now.TotalSeconds);
         WindowManager.Shared.Present(alert);
     }
 


### PR DESCRIPTION
Very quick fixes to allow your mod to run on 2024.6.

Removes the "allow couple" button from Road mode, as the stopBeforeCar value has been removed/redone.
Otherwise should work as normal.